### PR TITLE
add static method for cloning

### DIFF
--- a/src/Engine.ts
+++ b/src/Engine.ts
@@ -2,10 +2,23 @@ import { BVHNode } from './BVHNode';
 import { AABB } from './AABB';
 import { Bin } from './Bin';
 import { BestSplit } from './Bestsplit';
-import { expandToMin, expandToMax, surfaceArea, intersectAABB } from './utils';
+import { expandToMin, expandToMax, surfaceArea, intersectAABB, simpleDeepClone } from './utils';
 import type { IPrimitive, IBoxALike } from './types';
 
 export class Engine {
+  public static from(obj: {
+    bvhNodes: BVHNode[],
+    primitiveIndices: number[],
+  }) {
+    const e = new Engine();
+
+    e.bvhNodes = simpleDeepClone(obj.bvhNodes);
+    e.primitiveIndices = simpleDeepClone(obj.primitiveIndices);
+    e.nodesUsed = e.bvhNodes!.length;
+
+    return e;
+  }
+
   private bvhNodes: BVHNode[] | null = null;
   private primitiveIndices: number[] | null = null;
   private nodesUsed: number = 1;

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -12,3 +12,11 @@ export function surfaceArea(box: IBoxALike): number {
 
   return xLen * yLen + yLen * zLen + zLen * xLen;
 }
+
+export function simpleDeepClone<S = any>(serializable: S) {
+  try {
+    return JSON.parse(JSON.stringify(serializable));
+  } catch {
+    return serializable;
+  }
+}


### PR DESCRIPTION
+ `Engine.from` allows creating a new instance from an object (usually created by another instance of Engine).
+ This will make it handy when Engine instances are passed between different context (main thread and worker, for example).